### PR TITLE
Fix compilation error

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -155,7 +155,7 @@ shorten (n :/: d) = (n `div` f) :/: (d `div` f)
 -- Hint: DIV can easy be implemented by MUL with the reciprocal
 evalOp :: Op -> Rat -> Rat -> Rat  
 evalOp ADD (ln :/: ld) (rn :/: rd) = shorten (((ln * rd) + (rn * ld)) :/: (ld * rd))
-evalOp = todo
+evalOp _ _ _ = todo
 
 evalOpSpec :: Spec
 evalOpSpec = 


### PR DESCRIPTION
This was the error I got:

```
Equations for ‘evalOp’ have different numbers of arguments
```

With this fix, students can compile and run the tests right from the start, before reaching the task of `evalOp`.